### PR TITLE
Adding field in Admin Configuration to show current IP

### DIFF
--- a/Block/Adminhtml/System/Config/Form/Field/DeveloperIps.php
+++ b/Block/Adminhtml/System/Config/Form/Field/DeveloperIps.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @package     Flancer32_Csp
+ * @author      Andre Santiago
+ * @email       admin@akkaweb.com
+ */
+namespace Flancer32\Csp\Block\Adminhtml\System\Config\Form\Field;
+
+use Magento\Backend\Block\Template\Context;
+use Magento\Framework\Data\Form\Element\AbstractElement;
+use Magento\Framework\HTTP\PhpEnvironment\RemoteAddress;
+use Psr\Log\LoggerInterface;
+
+class DeveloperIps extends \Magento\Config\Block\System\Config\Form\Field
+{
+    /**
+     * Template path
+     *
+     * @var string
+     */
+    protected $_template = 'Flancer32_Csp::system/config/developer_ips.phtml';
+    protected $_remoteAddress;
+    protected $_logger;
+
+    /**
+     * @param Context $context
+     * @param RemoteAddress $remoteAddress
+     * @param array $data
+     */
+    public function __construct(
+        Context $context,
+        RemoteAddress $remoteAddress
+    ) {
+        parent::__construct($context);
+        $this->_remoteAddress = $remoteAddress;
+    }
+
+    /**
+     * Remove scope label
+     *
+     * @param  AbstractElement $element
+     * @return string
+     */
+    public function render(AbstractElement $element)
+    {
+        $element->unsScope()->unsCanUseWebsiteValue()->unsCanUseDefaultValue();
+        return parent::render($element);
+    }
+
+    /**
+     * Return element html
+     *
+     * @param  AbstractElement $element
+     * @return string
+     */
+    protected function _getElementHtml(AbstractElement $element)
+    {
+        return $this->_toHtml();
+    }
+
+    /**
+     * return String IP address
+     */
+    public function getIpAddress()
+    {
+        return $this->_remoteAddress->getRemoteAddress();
+    }
+}
+

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -61,6 +61,10 @@
                         <field id="fl32_csp/reports/developer_only">1</field>
                     </depends>
                 </field>
+                <field id="your_ip" translate="label comment" type="text" sortOrder="201" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Your IP Address</label>
+                    <frontend_model>Flancer32\Csp\Block\Adminhtml\System\Config\Form\Field\DeveloperIps</frontend_model>
+                </field>
                 <depends>
                     <field id="fl32_csp/general/enabled">1</field>
                 </depends>

--- a/view/adminhtml/system/config/developer_ips.phtml
+++ b/view/adminhtml/system/config/developer_ips.phtml
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @var $block \Flancer32\Csp\Block\Adminhtml\System\Config\Form\Field\DeveloperIps
+ */
+?>
+<div><?= $block->getIpAddress(); ?></div>


### PR DESCRIPTION
This will allow developers working on sites behind VPNs where IP might not be so obvious to show the actual IP that Magento sees from the developer. 

For me I actually created an extension of this module allowing this override. However, I will remove the module once this is reviewed, approved and released.

I could not use this module because I was behind VPN on many sites I work on and the IP sometimes changes.